### PR TITLE
Improve the performance of EntityActivator

### DIFF
--- a/Entities/CloneSpawner.cs
+++ b/Entities/CloneSpawner.cs
@@ -240,13 +240,16 @@ namespace Celeste.Mod.PandorasBox
 
             orig(self);
 
-            var players = self.Scene.Tracker.GetEntities<Player>();
-
-            if (players.Count > 1 && visibleBeforeOrig && !self.Collidable && self.Scene.OnInterval(0.05f, getSpinnerOffset(self)))
+            if (visibleBeforeOrig && !self.Collidable && self.Scene.OnInterval(0.05f, getSpinnerOffset(self)))
             {
-                foreach (Player entity in players)
+                var players = self.Scene.Tracker.GetEntities<Player>();
+
+                if (players.Count > 1)
                 {
-                    self.Collidable = self.Collidable || (Math.Abs(entity.X - self.X) < 128f && Math.Abs(entity.Y - self.Y) < 128f);
+                    foreach (Player entity in players)
+                    {
+                        self.Collidable = self.Collidable || (Math.Abs(entity.X - self.X) < 128f && Math.Abs(entity.Y - self.Y) < 128f);
+                    }
                 }
             }
         }

--- a/Entities/EntityActivator.cs
+++ b/Entities/EntityActivator.cs
@@ -42,7 +42,7 @@ namespace Celeste.Mod.PandorasBox
         public EffectModes Mode;
         public ActivationModes ActivationMode;
 
-        public List<Type> Targets;
+        public HashSet<Type> Targets;
 
         public bool UseTracked;
 

--- a/Helpers/TypeHelper.cs
+++ b/Helpers/TypeHelper.cs
@@ -20,9 +20,9 @@ namespace Celeste.Mod.PandorasBox
             return FakeAssembly.GetFakeEntryAssembly().GetType(name);
         }
 
-        public static List<Type> GetTypesFromString(string name, char sep=',')
+        public static HashSet<Type> GetTypesFromString(string name, char sep=',')
         {
-            List<Type> types = new List<Type>();
+            HashSet<Type> types = new HashSet<Type>();
 
             if (string.IsNullOrEmpty(name))
             {
@@ -37,12 +37,12 @@ namespace Celeste.Mod.PandorasBox
             return types;
         }
 
-        public static List<Entity> FindTargetEntities(Scene scene, List<Type> targets, bool useTracked)
+        public static List<Entity> FindTargetEntities(Scene scene, HashSet<Type> targets, bool useTracked)
         {
             return useTracked ? FindTargetEntitiesTracked(scene, targets) : FindTargetEntitiesUntracked(scene, targets);
         }
 
-        public static List<Entity> FindTargetEntitiesTracked(Scene scene, List<Type> targets)
+        public static List<Entity> FindTargetEntitiesTracked(Scene scene, HashSet<Type> targets)
         {
             List<Entity> entities = new List<Entity>();
 
@@ -57,7 +57,7 @@ namespace Celeste.Mod.PandorasBox
             return entities;
         }
 
-        public static List<Entity> FindTargetEntitiesUntracked(Scene scene, List<Type> targets)
+        public static List<Entity> FindTargetEntitiesUntracked(Scene scene, HashSet<Type> targets)
         {
             List<Entity> entities = scene.Entities.Where(entity => targets.Contains(entity.GetType())).ToList();
 


### PR DESCRIPTION
Use hashset instead of list when finding the target entities to improve the performance of EntityActivator.

Test on [spring collab tas](https://discord.com/channels/403698615446536203/854300208058073098/920851763450511410)

Before
![image](https://user-images.githubusercontent.com/181192/146892776-e6959f61-28a6-4eb0-bcec-2b695b731d80.png)
![image](https://user-images.githubusercontent.com/181192/147075362-a74d7465-91e2-4301-be52-8ed751140777.png)

After
![image](https://user-images.githubusercontent.com/181192/146892831-948c1a99-242a-4049-a0b9-718fddccfcc3.png)
![image](https://user-images.githubusercontent.com/181192/147075298-47e59b39-1392-4e01-b4e1-0540f6162f91.png)
